### PR TITLE
Added Additional Pass-thru Agent Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A Custom Http Handler that implements RUTA for: https://jira.sonarsource.com/bro
 SonarQube scanners DO NOT support anything other then basic\token based authentication. I've created a module that attempts to detect when the connecting application is a scanner or includes a token. When a scanner is detected the module will then bypass the windows authentication process. Right now the bypass conditions are:
 *  If there is an Authorization header with Basic auth
     * this indicates a token is present
-*  If the user agent of the request starts with any of the agent strings listed in the web.config setting: PassThruAgents
-    *  Initial configuration: sonar.scanner.app, SonarQubeScanner
+*  If the user agent of the request starts with any of the case-sensitive agent strings listed in the web.config setting: PassThruAgents
+    *  Initial configuration: sonar.scanner.app, SonarQubeScanner, ScannerCli, ScannerCLI, ScannerMSBuild, ScannerAzureDevOps
 
 I've only tested this with the MsBuild scanner so the agent list may need to be expanded. 
 

--- a/web-user.config
+++ b/web-user.config
@@ -50,6 +50,9 @@
             <string>sonar.scanner.app</string>
             <string>SonarQubeScanner</string>
             <string>ScannerCli</string>
+            <string>ScannerCLI</string>
+            <string>ScannerMSBuild</string>
+            <string>ScannerAzureDevOps</string>
           </ArrayOfString>
         </value>
       </setting>


### PR DESCRIPTION
We noticed that `ScannerMSBuild` and `ScannerAzureDevOps` were not
bypassing Windows Auth. Also noted that the string comparison is
case-sensitive, so needed to add `ScannerCLI` (in addition to the
already-present `ScannerCli`).